### PR TITLE
Using UTF8

### DIFF
--- a/import-natural-earth.sh
+++ b/import-natural-earth.sh
@@ -7,7 +7,7 @@ readonly PGCONN="dbname=$POSTGRES_DB user=$POSTGRES_USER host=$POSTGRES_HOST pas
 
 function import_natural_earth() {
     echo "Importing Natural Earth to PostGIS"
-    PGCLIENTENCODING=LATIN1 ogr2ogr \
+    PGCLIENTENCODING=UTF8 ogr2ogr \
     -progress \
     -f Postgresql \
     -s_srs EPSG:4326 \


### PR DESCRIPTION
Natural Earth data is in UTF-8, importing it as LATIN1 produces weird characters.

This PR sets to import to the correct characterset